### PR TITLE
fix: Escape apostrophe in JSX using &apos; entity (#80)

### DIFF
--- a/src/app/tourist/book/page.tsx
+++ b/src/app/tourist/book/page.tsx
@@ -876,7 +876,7 @@ function BookDestinationForm() {
                 <div className="mt-8 p-4 bg-blue-50/50 rounded-xl border border-blue-100 flex items-start space-x-3">
                   <Info className="h-5 w-5 text-blue-600 mt-0.5" />
                   <p className="text-sm text-blue-800 leading-relaxed">
-                    This trip's emissions are equivalent to <strong>{carbonFootprint.comparison.trees_equivalent}</strong> trees absorbing CO2 for a year, or <strong>{carbonFootprint.comparison.car_miles_equivalent}</strong> miles driven in an average car.
+                    This trip&apos;s emissions are equivalent to <strong>{carbonFootprint.comparison.trees_equivalent}</strong> trees absorbing CO2 for a year, or <strong>{carbonFootprint.comparison.car_miles_equivalent}</strong> miles driven in an average car.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
Escaped the raw apostrophe in `page.tsx` to prevent JSX parsing issues.

**Changes:**
- Changed `This trip's` to `This trip&apos;s`.

Closes #80 