### PR TITLE
chore: Add .gitattributes for consistent line endings (#83)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto eol=lf
-*.[cmd,[cC][mM][dD]} text eol=crlf
-*.[bat,[bB][aA][tT]} text eol=crlf
+*.[cC][mM][dD] text eol=crlf
+*.[bB][aA][tT] text eol=crlf


### PR DESCRIPTION
Added .gitattributes to enforce consistent line endings across different operating systems.
Closes #83 